### PR TITLE
updated dependencies for compatibility with Nifi 1.2.0

### DIFF
--- a/nifi-OpenScoringProcessor-nar/pom.xml
+++ b/nifi-OpenScoringProcessor-nar/pom.xml
@@ -16,18 +16,18 @@
 	<parent>
 		<groupId>com.simonellistonball.nifi</groupId>
 		<artifactId>nifi-ml-bundle</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>0.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>nifi-ml-nar</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>nar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.simonellistonball.nifi</groupId>
 			<artifactId>nifi-OpenScoringProcessor-processors</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>0.0.2-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.nifi</groupId>
 				<artifactId>nifi-nar-maven-plugin</artifactId>
-				<version>1.1.0</version>
+				<version>1.2.0</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/nifi-OpenScoringProcessor-processors/pom.xml
+++ b/nifi-OpenScoringProcessor-processors/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.simonellistonball.nifi</groupId>
 		<artifactId>nifi-ml-bundle</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>0.0.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>nifi-OpenScoringProcessor-processors</artifactId>
@@ -75,5 +75,5 @@
 		</dependency>
 
 	</dependencies>
-	<groupId>com.simonellistonball.nifi</groupId>
+
 </project>

--- a/nifi-OpenScoringProcessor-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-OpenScoringProcessor-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-${groupId}.processors.${artifactBaseName}.MyProcessor
+com.simonellistonball.nifi.processors.OpenScoringProcessor.OpenScoringProcessor

--- a/pom.xml
+++ b/pom.xml
@@ -19,18 +19,16 @@
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>
-        <version>0.6.1</version>
+        <version>1.4.0</version>
     </parent>
 
     <groupId>com.simonellistonball.nifi</groupId>
     <artifactId>nifi-ml-bundle</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
         <module>nifi-OpenScoringProcessor-processors</module>
-        
-        
         <module>nifi-OpenScoringProcessor-nar</module>
     </modules>
 


### PR DESCRIPTION
Updated the 'nifi-nar-bundles' and 'nifi-nar-maven-plugin' dependencies for compatibility with the current version of Nifi.